### PR TITLE
Test db scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ dotenvy = "0.15"
 poem = "3"
 poem-openapi = { version = "5", features = ["swagger-ui"] }
 reqwest = "0.12"
+secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "migrate"] }
 thiserror = "2"
@@ -16,3 +17,4 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ FROM gcr.io/distroless/cc-debian12
 
 WORKDIR /app
 
-# Copy the correct binary name (should match your Cargo.toml name)
+# Copy the correct binary name
 COPY --from=builder /app/target/release/lgr_ehr /app/lgr_ehr
 
-# Copy CA certificates from builder (Alpine has them)
+# Copy CA certificates from builder
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,14 @@ services:
     depends_on:
       - db
     environment:
-      - APP_HOST=0.0.0.0
-      - APP_PORT=3000
-      - DATABASE_URL=postgres://postgres:postgres@db:5432/ehr
-      - RUST_LOG=info,sqlx=warn
+      - APP_HOST=${APP_HOST}
+      - APP_PORT=${APP_PORT}
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - RUST_LOG=${RUST_LOG}
     ports: ["3000:3000"]
     volumes:
       - logs_volume:/app/logs
@@ -21,9 +25,9 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=ehr
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
     ports:
       - "5432:5432"
     volumes:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,8 @@ pub struct EHRApp {
 }
 
 impl EHRApp {
-    pub fn build(
-            config: AppSettings,
-    ) -> Self {
-        EHRApp {
-            config,
-        }
+    pub fn build(config: AppSettings) -> Self {
+        EHRApp { config }
     }
 
     pub async fn run(&self) -> Result<(), std::io::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,9 @@ use lgr_ehr::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = AppSettings::from_env();
-    init_tracing();
+    init_tracing(config.log_level());
 
-    let address = format!("{}:{}", config.app_host, config.app_port);
-
-    let app = EHRApp::build(address);
+    let app = EHRApp::build(config);
     app.run().await?;
 
     Ok(())

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,33 +1,115 @@
-use serde::Deserialize;
+use secrecy::SecretString;
 
-#[derive(Deserialize, Clone)]
+#[derive(Clone)]
 pub struct AppSettings {
-    pub app_host: String,
-    pub app_port: u16,
-    pub database_url: String,
-    pub rust_log: String,
+    app_host: String,
+    app_port: u16,
+    database_url: SecretString,
+    log_level: String,
 }
 
 impl AppSettings {
+    // Load settings from environment variables
     pub fn from_env() -> Self {
         dotenvy::dotenv().ok();
 
-        // TODO: hide sensitive DB information
+        // App settings
+        let app_host = std::env::var("APP_HOST")
+            .expect("APP_HOST must be set in .env or environment");
 
-        let app_host = std::env::var("APP_HOST").unwrap_or_else(|_| "0.0.0.0".into());
         let app_port = std::env::var("APP_PORT")
-            .unwrap_or_else(|_| "3000".into())
+            .expect("APP_PORT must be set in .env or environment")
             .parse()
             .unwrap_or(3000);
-        let database_url = std::env::var("DATABASE_URL")
-            .unwrap_or_else(|_| "postgres://postgres:postgres@db:5432/ehr".into());
-        let rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info,sqlx=warn".into());
+
+        // Database settings
+        let db_password = std::env::var("DB_PASSWORD")
+            .expect("DB_PASSWORD must be set in .env or environment");
+
+        let db_host = std::env::var("DB_HOST")
+            .expect("DB_HOST must be set in .env or environment");
+        let db_port = std::env::var("DB_PORT")
+            .expect("DB_PORT must be set in .env or environment");
+        let db_name = std::env::var("DB_NAME")
+            .expect("DB_NAME must be set in .env or environment");
+        let db_user = std::env::var("DB_USER")
+            .expect("DB_USER must be set in .env or environment");
+
+        // Construct the database URL
+        let database_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        // Logging settings
+        let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".into());
 
         Self {
             app_host,
             app_port,
-            database_url,
-            rust_log,
+            database_url: SecretString::from(database_url),
+            log_level,
         }
+    }
+
+    // Builder for tests w/ specific DB URL
+    pub fn for_tests(database_url: SecretString) -> Self {
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+
+        Self {
+            app_host: "127.0.0.1".into(),
+            app_port: port,
+            database_url,
+            log_level: "info".into(),
+        }
+    }
+
+    // Helper methods to access settings
+    pub fn database_url(&self) -> &SecretString {
+        &self.database_url
+    }
+
+    // Returns the full application address in the format "host:port"
+    pub fn app_address(&self) -> String {
+        format!("{}:{}", self.app_host, self.app_port)
+    }
+
+    // Returns the logging level
+    pub fn log_level(&self) -> &str {
+        &self.log_level
+    }
+
+    // Helper function to build database URL for any database name
+    fn build_database_url(db_name: &str) -> SecretString {
+        dotenvy::dotenv().ok();
+        
+        let db_user = std::env::var("DB_USER")
+            .expect("DB_USER must be set in .env or environment");
+        let db_password = std::env::var("DB_PASSWORD")
+            .expect("DB_PASSWORD must be set in .env or environment");
+        let db_host = "localhost";
+        let db_port = std::env::var("DB_PORT")
+            .expect("DB_PORT must be set in .env or environment");
+        
+        let db_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+        
+        SecretString::from(db_url)
+    }
+
+    // Build admin database URL (connects to "postgres" database)
+    pub fn admin_database_url() -> SecretString {
+        Self::build_database_url("postgres")
+    }
+
+    // Build database URL for a specific database name
+    pub fn database_url_for(db_name: &str) -> SecretString {
+        Self::build_database_url(db_name)
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -14,8 +14,8 @@ impl AppSettings {
         dotenvy::dotenv().ok();
 
         // App settings
-        let app_host = std::env::var("APP_HOST")
-            .expect("APP_HOST must be set in .env or environment");
+        let app_host =
+            std::env::var("APP_HOST").expect("APP_HOST must be set in .env or environment");
 
         let app_port = std::env::var("APP_PORT")
             .expect("APP_PORT must be set in .env or environment")
@@ -23,23 +23,17 @@ impl AppSettings {
             .unwrap_or(3000);
 
         // Database settings
-        let db_password = std::env::var("DB_PASSWORD")
-            .expect("DB_PASSWORD must be set in .env or environment");
+        let db_password =
+            std::env::var("DB_PASSWORD").expect("DB_PASSWORD must be set in .env or environment");
 
-        let db_host = std::env::var("DB_HOST")
-            .expect("DB_HOST must be set in .env or environment");
-        let db_port = std::env::var("DB_PORT")
-            .expect("DB_PORT must be set in .env or environment");
-        let db_name = std::env::var("DB_NAME")
-            .expect("DB_NAME must be set in .env or environment");
-        let db_user = std::env::var("DB_USER")
-            .expect("DB_USER must be set in .env or environment");
+        let db_host = std::env::var("DB_HOST").expect("DB_HOST must be set in .env or environment");
+        let db_port = std::env::var("DB_PORT").expect("DB_PORT must be set in .env or environment");
+        let db_name = std::env::var("DB_NAME").expect("DB_NAME must be set in .env or environment");
+        let db_user = std::env::var("DB_USER").expect("DB_USER must be set in .env or environment");
 
         // Construct the database URL
-        let database_url = format!(
-            "postgres://{}:{}@{}:{}/{}",
-            db_user, db_password, db_host, db_port, db_name
-        );
+        let database_url =
+            format!("postgres://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}");
 
         // Logging settings
         let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".into());
@@ -86,20 +80,15 @@ impl AppSettings {
     // Helper function to build database URL for any database name
     fn build_database_url(db_name: &str) -> SecretString {
         dotenvy::dotenv().ok();
-        
-        let db_user = std::env::var("DB_USER")
-            .expect("DB_USER must be set in .env or environment");
-        let db_password = std::env::var("DB_PASSWORD")
-            .expect("DB_PASSWORD must be set in .env or environment");
+
+        let db_user = std::env::var("DB_USER").expect("DB_USER must be set in .env or environment");
+        let db_password =
+            std::env::var("DB_PASSWORD").expect("DB_PASSWORD must be set in .env or environment");
         let db_host = "localhost";
-        let db_port = std::env::var("DB_PORT")
-            .expect("DB_PORT must be set in .env or environment");
-        
-        let db_url = format!(
-            "postgres://{}:{}@{}:{}/{}",
-            db_user, db_password, db_host, db_port, db_name
-        );
-        
+        let db_port = std::env::var("DB_PORT").expect("DB_PORT must be set in .env or environment");
+
+        let db_url = format!("postgres://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}");
+
         SecretString::from(db_url)
     }
 

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -4,10 +4,7 @@ use tracing_appender::{
 };
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, registry, util::SubscriberInitExt};
 
-use crate::utils::config::AppSettings;
-
-pub fn init_tracing() {
-    let settings = AppSettings::from_env();
+pub fn init_tracing(log_level: &str) {
     let file_appender = RollingFileAppender::new(Rotation::DAILY, "./logs", "lgr_ehr.log");
 
     let (non_blocking_file, _guard) = non_blocking(file_appender);
@@ -28,7 +25,7 @@ pub fn init_tracing() {
                 .with_writer(non_blocking_stdout)
                 .with_ansi(true),
         )
-        .with(EnvFilter::new(&settings.rust_log))
+        .with(EnvFilter::new(log_level))
         .init();
 
     std::mem::forget(_guard);

--- a/tests/api/health.rs
+++ b/tests/api/health.rs
@@ -2,11 +2,13 @@ use crate::helpers::TestApp;
 
 #[tokio::test]
 async fn test_health_check() {
-    let app = TestApp::new().await;
+    let mut app = TestApp::new().await;
 
     let response = app.health_check().await;
 
     assert_eq!(response.status(), 200);
     let body = response.text().await.unwrap();
     assert_eq!(body, "EHR API is running");
+
+    app.cleanup().await;
 }

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -1,32 +1,42 @@
-use lgr_ehr::EHRApp;
+use lgr_ehr::{utils::config::AppSettings, EHRApp};
+use secrecy::ExposeSecret;
+use sqlx::{postgres::PgPoolOptions, Executor, PgPool};
 
 pub struct TestApp {
     address: String,
     http_client: reqwest::Client,
+    _db_pool: PgPool,
+    db_name: String,
+    cleanup_called: bool,
 }
 
 impl TestApp {
     pub async fn new() -> Self {
-        let port = std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port();
+        // Create test database first
+        let (db_pool, db_name) = create_test_database().await;
 
-        let address = format!("127.0.0.1:{}", port);
+        // Create database URL for the test database
+        let test_db_url = AppSettings::database_url_for(&db_name);
 
-        let app = EHRApp::build(address.clone());
+        // Create settings with test database
+        let settings = AppSettings::for_tests(test_db_url);
+        let app = EHRApp::build(settings.clone());
 
-        #[allow(clippy::let_underscore_future)]
-        let _ = tokio::spawn(async move { app.run().await });
-        tokio::time::sleep(std::time::Duration::from_millis(0)).await;
+        // Spawn the server
+        tokio::spawn(async move {
+            app.run().await.expect("Failed to start test server")
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let address = format!("http://{address}");
+        let address = format!("http://{}", settings.app_address());
         let http_client = reqwest::Client::new();
 
         Self {
             address,
             http_client,
+            _db_pool: db_pool,
+            db_name,
+            cleanup_called: false,
         }
     }
 
@@ -36,5 +46,83 @@ impl TestApp {
             .send()
             .await
             .expect("Failed to execute request")
+    }
+
+    pub async fn cleanup(&mut self) {
+        if !self.cleanup_called {
+            cleanup_test_database(&self.db_name).await;
+            self.cleanup_called = true;
+        }
+    }
+}
+
+// Panic if TestApp is dropped without cleanup
+impl Drop for TestApp {
+    fn drop(&mut self) {
+        if !self.cleanup_called {
+            panic!("TestApp was dropped without calling cleanup(). Database {} may not be deleted.", self.db_name);
+       }
+    }
+}
+
+async fn create_test_database() -> (PgPool, String) {
+    // Generate unique database name
+    let db_name = format!("test_{}", uuid::Uuid::new_v4().simple());
+
+    // Get admin database URL from environment
+    let admin_db_url = AppSettings::admin_database_url();
+
+    // Connect to postgres admin database
+    let admin_connection = PgPoolOptions::new()
+        .connect(&admin_db_url.expose_secret())
+        .await
+        .expect("Failed to connect to PostgreSQL admin database");
+
+    // Create the test database
+    admin_connection
+        .execute(format!(r#"CREATE DATABASE "{}";"#, db_name).as_str())
+        .await
+        .expect("Failed to create test database");
+
+    // Connect to the new test database
+    let test_db_url = AppSettings::database_url_for(&db_name);
+
+    let test_connection = PgPoolOptions::new()
+        .connect(&test_db_url.expose_secret())
+        .await
+        .expect("Failed to connect to test database");
+
+    // Run migrations on the test database
+    sqlx::migrate!("./migrations")
+        .run(&test_connection)
+        .await
+        .expect("Failed to run migrations on test database");
+
+    (test_connection, db_name)
+}
+
+async fn cleanup_test_database(db_name: &str) {
+    let admin_db_url = AppSettings::admin_database_url();
+
+    if let Ok(admin_connection) = PgPoolOptions::new().connect(&admin_db_url.expose_secret()).await {
+        // Terminate connections to test database
+        let _ = admin_connection
+            .execute(
+                format!(
+                    r#"
+                    SELECT pg_terminate_backend(pg_stat_activity.pid)
+                    FROM pg_stat_activity
+                    WHERE pg_stat_activity.datname = '{}'
+                    AND pid <> pg_backend_pid();"#,
+                    db_name
+                )
+                .as_str(),
+            )
+            .await;
+
+        // Drop the test database
+        let _ = admin_connection
+            .execute(format!(r#"DROP DATABASE IF EXISTS "{}";"#, db_name).as_str())
+            .await;
     }
 }

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -1,6 +1,6 @@
-use lgr_ehr::{utils::config::AppSettings, EHRApp};
+use lgr_ehr::{EHRApp, utils::config::AppSettings};
 use secrecy::ExposeSecret;
-use sqlx::{postgres::PgPoolOptions, Executor, PgPool};
+use sqlx::{Executor, PgPool, postgres::PgPoolOptions};
 
 pub struct TestApp {
     address: String,
@@ -23,9 +23,7 @@ impl TestApp {
         let app = EHRApp::build(settings.clone());
 
         // Spawn the server
-        tokio::spawn(async move {
-            app.run().await.expect("Failed to start test server")
-        });
+        tokio::spawn(async move { app.run().await.expect("Failed to start test server") });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let address = format!("http://{}", settings.app_address());
@@ -60,8 +58,11 @@ impl TestApp {
 impl Drop for TestApp {
     fn drop(&mut self) {
         if !self.cleanup_called {
-            panic!("TestApp was dropped without calling cleanup(). Database {} may not be deleted.", self.db_name);
-       }
+            panic!(
+                "TestApp was dropped without calling cleanup(). Database {} may not be deleted.",
+                self.db_name
+            );
+        }
     }
 }
 
@@ -104,7 +105,10 @@ async fn create_test_database() -> (PgPool, String) {
 async fn cleanup_test_database(db_name: &str) {
     let admin_db_url = AppSettings::admin_database_url();
 
-    if let Ok(admin_connection) = PgPoolOptions::new().connect(&admin_db_url.expose_secret()).await {
+    if let Ok(admin_connection) = PgPoolOptions::new()
+        .connect(&admin_db_url.expose_secret())
+        .await
+    {
         // Terminate connections to test database
         let _ = admin_connection
             .execute(


### PR DESCRIPTION
I apologize in advance, I know this pull request is messier than it should be, and I will work on making this cleaner in future code review requests. There's a handful of changes in here, but the code updates I'm interested in getting feedback on is the setup for integration tests with the poem app. Specifically the following:

1. In src/utils/config.rs created a AppSettings struct which has associated functions for generating app connection info and db connection info to use when spinning up the app either in production or in the testing environment.

2. In tests/api/helpers.rs I created a framework for spinning up a test app with a test db, based on what we did in the auth service, just a little bit different structure with poem vs. axum

3. In test/api/health.rs I created a simple integration test for calling the health route for the app (in src/lib.rs)

4. The app uses the config.rs AppSettings struct as well in main.rs / lib.rs